### PR TITLE
Use channel and username from options when using custom formatter

### DIFF
--- a/lib/winston-slack.js
+++ b/lib/winston-slack.js
@@ -44,10 +44,10 @@ Slack.prototype.log = function (level, msg, meta, callback) {
     //- Use custom formatter for message if set
     var message = this.customFormatter
         ? this.customFormatter(level, msg, meta)
-        : { text: "[" + level + "] " + msg,
-            channel: this.channel,
-            username: this.username
-        };
+        : { text: "[" + level + "] " + msg };
+
+    message.channel = this.channel;
+    message.username = this.usernam;
     this.slack.send(message);
 
     callback(null, true);


### PR DESCRIPTION
I was trying out winston as a logger and integrate it with slack which we use for work, and stumbled across your library.

For our usecase we needed the custom formatter and I noticed that username and channel isn't appended to the message, so you need to have it doubled, which is IMO awkward.

So from
```javascript
winston.add(something, {
    domain: "yourcompany",
    apiToken: "j7w7tjBMdytjXzEZu9HQooni",
    channel: "#test-channel",
    username: "ErrorBot",
    level: 'error',
    handleExceptions : true,
    customFormatter: function (level, msg, meta) {
        return {
            text: "foo",
            channel: "#test-channel",
            username: "ErrorBot"
        }
    }
});
```
to
```javascript
winston.add(something, {
    domain: "yourcompany",
    apiToken: "j7w7tjBMdytjXzEZu9HQooni",
    channel: "#test-channel",
    username: "ErrorBot",
    level: 'error',
    handleExceptions : true,
    customFormatter: function (level, msg, meta) {
        return {
            text: "foo"
        }
    }
});
```
